### PR TITLE
Print explicit board and platform sections in output JSON when readng signature

### DIFF
--- a/usersiggen/usersiggen.go
+++ b/usersiggen/usersiggen.go
@@ -22,7 +22,7 @@ import "github.com/satori/go.uuid"
 
 var g_version_major uint8 = 3
 var g_version_minor uint8 = 0
-var g_version_patch uint8 = 1
+var g_version_patch uint8 = 2
 
 const SIGNATURE_TYPE_EUI64 = 0     // EUI64 is the IEEE Extended Unique Identifier
 const SIGNATURE_TYPE_BOARD = 1     // Boards are the core of the system - MCU

--- a/usersiggen/usersiggen.go
+++ b/usersiggen/usersiggen.go
@@ -21,7 +21,7 @@ import "github.com/joaojeronimo/go-crc16"
 import "github.com/satori/go.uuid"
 
 var g_version_major uint8 = 3
-var g_version_minor uint8 = 0
+var g_version_minor uint8 = 1
 var g_version_patch uint8 = 0
 
 const SIGNATURE_TYPE_EUI64 = 0     // EUI64 is the IEEE Extended Unique Identifier
@@ -430,7 +430,7 @@ func readSigsFromFile(filename string) ([]interface{}, error) {
 		}
 
 		switch bsig.Signature_type {
-		case SIGNATURE_TYPE_EUI64: 
+		case SIGNATURE_TYPE_EUI64:
 			eui_sig, err := sig.DeserializeEui(sigdata_in[rd:])
 			if err != nil {
 				fmt.Printf("Failed to deserialize EUI (%s)\n", err)
@@ -438,7 +438,7 @@ func readSigsFromFile(filename string) ([]interface{}, error) {
 			}
 			sigs = append(sigs, eui_sig)
 
-		case SIGNATURE_TYPE_BOARD: 
+		case SIGNATURE_TYPE_BOARD:
 			// Lazy deserialization, structure for board and platform sigs is same as component
 			comp_sig, err := sig.DeserializeComponent(sigdata_in[rd:])
 			if err != nil {
@@ -446,8 +446,8 @@ func readSigsFromFile(filename string) ([]interface{}, error) {
 				return sigs, err
 			}
 			sigs = append(sigs, comp_sig)
-		 
-		case SIGNATURE_TYPE_PLATFORM: 
+
+		case SIGNATURE_TYPE_PLATFORM:
 			// Lazy deserialization, structure for board and platform sigs is same as component
 			comp_sig, err := sig.DeserializeComponent(sigdata_in[rd:])
 			if err != nil {
@@ -456,15 +456,15 @@ func readSigsFromFile(filename string) ([]interface{}, error) {
 			}
 			sigs = append(sigs, comp_sig)
 
-		case SIGNATURE_TYPE_COMPONENT: 
+		case SIGNATURE_TYPE_COMPONENT:
 			comp_sig, err := sig.DeserializeComponent(sigdata_in[rd:])
 			if err != nil {
 				fmt.Printf("Failed to deserialize ComponentSignature (%s)\n", err)
 				return sigs, err
 			}
 			sigs = append(sigs, comp_sig)
-		 
-		default: 
+
+		default:
 			//fmt.Printf("Unknown signature type %d\n", bsig.Signature_type)
 		}
 	}
@@ -477,17 +477,34 @@ func readSigsFromFile(filename string) ([]interface{}, error) {
 }
 
 func sigsToJson(sigs []interface{}) string {
-	sigmap := map[string]interface{}{"eui_signature": nil, "component_signatures": make([]interface{}, 0)}
+	sigmap := map[string]interface{}{
+		"eui_signature": nil,
+		"board_signature": nil,
+		"platform_signature": nil,
+		"component_signatures": make([]interface{}, 0)}
 	for _, sig := range sigs {
 		switch s := sig.(type) {
 		case EUISignature:
 			sigmap["eui_signature"] = s
 		case ComponentSignature:
-			if lst, ok := sigmap["component_signatures"].([]interface{}); ok {
-				sigmap["component_signatures"] = append(lst, s)
+			// Signatures of type Board, Platform and Component have the same
+			// structure so we use ComponentSignature structure to represent
+			// them all. The field 'Signature_type' holds the intended type.
+			sig_type := s.Signature_type
+			switch sig_type {
+			case SIGNATURE_TYPE_BOARD:
+				sigmap["board_signature"] = s
+			case SIGNATURE_TYPE_PLATFORM:
+				sigmap["platform_signature"] = s
+			case SIGNATURE_TYPE_COMPONENT:
+				if lst, ok := sigmap["component_signatures"].([]interface{}); ok {
+					sigmap["component_signatures"] = append(lst, s)
+				}
+			default:
+				fmt.Printf("Unknown signature type %d\n", sig_type)
 			}
 		default:
-			fmt.Printf("tp default")
+			fmt.Printf("tp default\n")
 		}
 	}
 

--- a/usersiggen/usersiggen.go
+++ b/usersiggen/usersiggen.go
@@ -21,8 +21,8 @@ import "github.com/joaojeronimo/go-crc16"
 import "github.com/satori/go.uuid"
 
 var g_version_major uint8 = 3
-var g_version_minor uint8 = 1
-var g_version_patch uint8 = 0
+var g_version_minor uint8 = 0
+var g_version_patch uint8 = 1
 
 const SIGNATURE_TYPE_EUI64 = 0     // EUI64 is the IEEE Extended Unique Identifier
 const SIGNATURE_TYPE_BOARD = 1     // Boards are the core of the system - MCU


### PR DESCRIPTION
Instead of this:

```
{
        "component_signatures": [
                {
                        "sig_version_major": 3,
                        "sig_version_minor": 0,
                        "sig_version_patch": 0,
                        "signature_size": 86,
                        "signature_type": 1,
                        "unix_time": 1578649382,
                        "component_uuid": "8643f0db-d872-4ce8-8f95-ff3beb8a66d2",
                        "component_name": "k-mob",
                        "pcb_version_major": 0,
                        "pcb_version_minor": 0,
                        "pcb_version_assembly": 1,
                        "serial_number": "00000000-0000-0000-0000-000000000000",
                        "manufacturer": "6a74c3fd-3538-4b5a-8d6e-42b71bfdfe4e",
                        "position": 0,
                        "data_length": 0
                },
                {
                        "sig_version_major": 3,
                        "sig_version_minor": 0,
                        "sig_version_patch": 0,
                        "signature_size": 86,
                        "signature_type": 2,
                        "unix_time": 1578649406,
                        "component_uuid": "a4e5e8ba-95f3-43a7-bfda-839d0e18a14e",
                        "component_name": "k-mob",
                        "pcb_version_major": 0,
                        "pcb_version_minor": 0,
                        "pcb_version_assembly": 1,
                        "serial_number": "00000000-0000-0000-0000-000000000000",
                        "manufacturer": "6a74c3fd-3538-4b5a-8d6e-42b71bfdfe4e",
                        "position": 0,
                        "data_length": 0
                }
        ],
        "eui_signature": {
                "sig_version_major": 3,
                "sig_version_minor": 0,
                "sig_version_patch": 0,
                "signature_size": 24,
                "signature_type": 0,
                "unix_time": 1578649382,
                "eui64": "70B3D5E390004801"
        }
}

```

output this:

```
{                                                                                                                                                                                                                  
        "board_signature": {                                                                                                                                                                                       
                "sig_version_major": 3,                                                                                                                                                                            
                "sig_version_minor": 0,                                                                                                                                                                            
                "sig_version_patch": 0,                                                                  
                "signature_size": 86,                                                                    
                "signature_type": 1,                                                                     
                "unix_time": 1578649382,                                                                                                                                                                           
                "component_uuid": "8643f0db-d872-4ce8-8f95-ff3beb8a66d2",                                                                                                                                          
                "component_name": "k-mob",                                                               
                "pcb_version_major": 0,                                                                                                                                                                            
                "pcb_version_minor": 0,                                                                  
                "pcb_version_assembly": 1,                                                               
                "serial_number": "00000000-0000-0000-0000-000000000000",                                 
                "manufacturer": "6a74c3fd-3538-4b5a-8d6e-42b71bfdfe4e",                                                                                                                                            
                "position": 0,                                                                           
                "data_length": 0                                                                         
        },                                                                                               
        "component_signatures": [],                                                                                                                                                                                
        "eui_signature": {                                                                               
                "sig_version_major": 3,                                                                                                                                                                            
                "sig_version_minor": 0,                                                                  
                "sig_version_patch": 0,                                                                  
                "signature_size": 24,                                                                    
                "signature_type": 0,                                                                     
                "unix_time": 1578649382,                                                                                                                                                                           
                "eui64": "70B3D5E390004801"                                                                                                                                                                        
        },                                                                                                                                                                                                         
        "platform_signature": {                                                                                                                                                                                    
                "sig_version_major": 3,
                "sig_version_minor": 0,
                "sig_version_patch": 0,
                "signature_size": 86,
                "signature_type": 2,
                "unix_time": 1578649406,
                "component_uuid": "a4e5e8ba-95f3-43a7-bfda-839d0e18a14e",
                "component_name": "k-mob",
                "pcb_version_major": 0,
                "pcb_version_minor": 0,
                "pcb_version_assembly": 1,
                "serial_number": "00000000-0000-0000-0000-000000000000",
                "manufacturer": "6a74c3fd-3538-4b5a-8d6e-42b71bfdfe4e",
                "position": 0,
                "data_length": 0
        }
}
```